### PR TITLE
Botones administrar reporte, Conexión a la base de datos en el pdf, arreglo de bugs menores.

### DIFF
--- a/site-php/ajax_handler/informe.php
+++ b/site-php/ajax_handler/informe.php
@@ -1,0 +1,41 @@
+<?php
+require_once('../includes/Database.class.php');
+header('Content-Type: application/json');
+
+if (isset($_POST)) {
+    $action = $_POST['action'];
+
+    switch ($action) {
+
+        case 'aprobar_informe':
+            $id = $_POST['id'];
+
+            $database = new Database();
+            $conn = $database->getConnection();
+            $stmt = $conn->prepare('UPDATE cctv_gestion_plantas SET estado = 1 WHERE id = :id');
+            $stmt->bindParam(':id', $id);
+            
+            if ($stmt->execute()) {
+                echo json_encode(['status' => true, 'message' => 'Reporte aprobado correctamente']);
+            } else {
+                echo json_encode(['status' => false, 'message' => 'El Reporte '.$id.' no se ha podido aprobado correctamente']);
+            }
+            break;
+        case 'desaprobar_informe':
+            $id = $_POST['id'];
+
+            $database = new Database();
+            $conn = $database->getConnection();
+            $stmt = $conn->prepare('UPDATE cctv_gestion_plantas SET estado = 0 WHERE id = :id');
+            $stmt->bindParam(':id', $id);
+            $stmt->execute();
+            
+            if ($stmt->execute()) {
+                echo json_encode(['status' => true, 'message' => 'Reporte desaprobado correctamente']);
+            } else {
+                echo json_encode(['status' => false, 'message' => 'El Reporte '.$id.' no se ha podido desaprobar correctamente']);
+            }
+            break;
+    }
+}
+?>

--- a/site-php/formularios.php
+++ b/site-php/formularios.php
@@ -2,6 +2,8 @@
 error_reporting( E_ALL );
 session_start();
 $formAccion = isset($_GET["form"]) ? $_GET["form"] : '';
+
+$perfilUsuario = isset($_SESSION["nombreperfil"]) ? $_SESSION["nombreperfil"] : '';
 ?>
 
 <!DOCTYPE html>

--- a/site-php/includes/Informes.class.php
+++ b/site-php/includes/Informes.class.php
@@ -1,0 +1,47 @@
+<?php
+    require_once('Database.class.php');
+
+    class Informes{
+        
+        public static function get_client_by_plant_id($id){
+            $database = new Database();
+            $conn = $database->getConnection();
+            $stmt = $conn->prepare('SELECT id_clientes FROM cctv_plantas WHERE id = :id');
+            $stmt->bindParam(':id', $id);
+            $stmt->execute();
+            $result = $stmt->fetch(PDO::FETCH_ASSOC);
+            $id_cliente = $result['id_clientes'];
+            $stmt = $conn->prepare('SELECT * FROM cctv_clientes WHERE id = :id_cliente');
+            $stmt->bindParam(':id_cliente', $id_cliente);
+            $stmt->execute();
+            $result = $stmt->fetch(PDO::FETCH_ASSOC);
+            return $result;
+        }
+
+        public static function get_plantas_by_informe_id($id){
+            $database = new Database();
+            $conn = $database->getConnection();
+            $stmt = $conn->prepare('SELECT id_plantas FROM cctv_gestion_plantas WHERE id = :id');
+            $stmt->bindParam(':id', $id);
+            $stmt->execute();
+            $result = $stmt->fetch(PDO::FETCH_ASSOC);
+            $id_planta = $result['id_plantas'];
+            $stmt = $conn->prepare('SELECT * FROM cctv_plantas WHERE id = :id_planta');
+            $stmt->bindParam(':id_planta', $id_planta);
+            $stmt->execute();
+            $result = $stmt->fetch(PDO::FETCH_ASSOC);
+            return $result;
+        }
+
+        public static function get_informe($id){
+            $database = new Database();
+            $conn = $database->getConnection();
+            $stmt = $conn->prepare('SELECT * FROM cctv_gestion_plantas WHERE id = :id');
+            $stmt->bindParam(':id', $id);
+            $stmt->execute();
+            $result = $stmt->fetch(PDO::FETCH_ASSOC);
+            return $result;
+        }
+    }
+
+?>

--- a/site-php/includes/Plantas.class.php
+++ b/site-php/includes/Plantas.class.php
@@ -72,10 +72,9 @@
             $stmt->bindParam(':id',$id);
             if($stmt->execute()){
                 $result = $stmt->fetchAll();
-                echo json_encode($result);
-                header('HTTP/1.1 201 OK');
+                return $result;
             } else {
-                header('HTTP/1.1 404 No se ha podido consultar las plantas');
+                return [];
             }
         }
 

--- a/site-php/informe.php
+++ b/site-php/informe.php
@@ -5,7 +5,7 @@
                                     <h3 class="card-title">Puedes buscar por planta, fecha, nombre usuario </h3>
                                 </div> <!-- /.card-header -->
                                 <div class="card-body">
-                                    <table id="datatable" class="display" style="width:100%">
+                                    <table id="datatable" class="table table-striped table-hover" style="width:100%">
                                         <thead>
                                             <tr>
                                                 <th>ID</th>
@@ -43,6 +43,9 @@
 <script src="https://cdn.datatables.net/1.11.5/js/jquery.dataTables.min.js"></script>
 <script>
     $(document).ready(function() {
+
+        var perfil = '<?php echo $perfilUsuario; ?>';
+
         tablaInforme = $('#datatable').DataTable({
             "processing": true,
             "serverSide": true,
@@ -62,24 +65,72 @@
                 { "data": "fecha_gestion" },
                 { "data": "fecha_registro" },
                 { "data": "estadoreporte" },
-                {"defaultContent": "<div class='text-center d-inline-block d-md-block'><div class='btn-group'><button class='btn btn-primary btn-sm btnEditar'><i class='material-icons'>assignment</i></button></div></div>"}
+                {"defaultContent": "<div class='text-center d-md-block'><div class='btn-group'><button class='btn btn-primary btn-sm btnEditar'><i class='material-icons'>assignment</i></button></div></div>"}
             ],
             "createdRow": function(row, data, dataIndex) {
-            $(row).attr('data-id', data.id); // Añadir atributo data-id
+                $(row).attr('data-id', data.id); // Añadir atributo data-id
+
+                if (data.estadoreporte !== 'Aprobado') {
+                    $(row).find('button.btnEditar').prop('disabled', true);
+                }
+
+                if(perfil === 'Admin' || perfil === 'Supervisor'){
+                    $(row).find('.btn-group').append('<button class="btn btn-success btn-sm"><i class="material-icons">check</i></button><button class="btn btn-danger btn-sm"><i class="material-icons">remove_done</i></button>');
+                    if(data.estadoreporte === 'Aprobado'){
+                        $(row).find('button.btn-success').prop('disabled', true);
+                    }else{
+                        $(row).find('button.btn-danger').prop('disabled', true);
+                    }
+                }
             },
             "language": {
                 "url": "./assets/json/espanol.json"
             }
+        });
+
+        $('#datatable tbody').on('click', '.btn-success , .btn-danger', function() {
+            var $row = $(this).closest('tr');
+            var data = tablaInforme.row($row).data();
+            var formularioId = data.id;
+            var action = $(this).hasClass('btn-success') ? 'aprobar_informe' : 'desaprobar_informe';
+
+            $.ajax({
+                url: "./ajax_handler/informe.php",
+                type: 'POST',
+                data: { action: action, id: formularioId },
+                success: function(response) {
+                    console.log(response);
+                    if(response.status) {
+                        if(action === 'aprobar_informe') {
+                            data.estadoreporte = 'Aprobado';
+                            $row.find('button.btn-success').prop('disabled', true);
+                            $row.find('button.btnEditar').prop('disabled', false);
+                        }else{
+                            data.estadoreporte = 'Por Aprobar';
+                            $row.find('button.btn-success').prop('disabled', false);
+                            $row.find('button.btn-danger').prop('disabled', true);
+                        }
+                        tablaInforme.row($row).data(data).draw(false);
+                    } else {
+                        alert("No se pudo aprobar el informe.");
+                    }
+                },
+                error: function(jqXHR, textStatus, errorThrown) {
+                    console.log('Error en AJAX:', textStatus, errorThrown);
+                }
+            });
         });
     });
 
 
     //Editar Turnos
     $('#datatable tbody').on('click', '.btnEditar', function() {
+        var $row = $(this).closest('tr');
         var data = tablaInforme.row($(this).parents('tr')).data();
-        var id = $(this).attr('id') || null;
-        alert(id);
-        window.open("reportetest.php?id_gestion_plantas=");
+        var data = tablaInforme.row($row).data();
+        var formularioId = data.id;
+        alert(formularioId);
+        window.open("reportetest.php?id_gestion_plantas=" + formularioId);
         //$('#formTurno').attr('data-action', 'edit_turno');
         //$('#formTurno').attr('data-id', data.id);
         //$('#nombre').val(data.nombre);

--- a/site-php/reportetest.php
+++ b/site-php/reportetest.php
@@ -1,16 +1,26 @@
 <?php
 require('fpdf.php');
+require_once('includes/Informes.class.php');
+require_once('includes/Camaras.class.php');
+$id = isset($_GET['id_gestion_plantas']);
+$datosCliente = Informes::get_client_by_plant_id($id);
+$planta = Informes::get_plantas_by_informe_id($id);
+$informe = Informes::get_informe($id);
+$camaras = Camaras::get_all_camaras($planta['id']);
+$arrayCamaras = [];
+foreach ($camaras as $camara) {
+    $arrayCamaras[] = [
+        'id' => $camara['nombre'],
+        'operatividad' => $camara['estado'] ? 'Operativa' : 'No Operativa',
+    ];
+}
 
 // Datos de ejemplo para un cliente
 $cliente = [
-    'nombre' => 'Cliente A',
-    'planta' => 'Planta 1',
-    'fecha_registro' => '2024-07-20',
-    'camaras' => [
-        ['id' => 1, 'operatividad' => 'Operativa'],
-        ['id' => 2, 'operatividad' => 'No Operativa'],
-        ['id' => 3, 'operatividad' => 'Operativa']
-    ]
+    'nombre' => $datosCliente['nombre'],
+    'planta' => $planta['nombre'],
+    'fecha_registro' => $informe['fecha_registro'],
+    'camaras' => $arrayCamaras
 ];
 
 class PDF extends FPDF
@@ -123,7 +133,7 @@ $pdf->Ln(10);
 $pdf->SetFont('Arial', 'B', 12);
 $pdf->Cell(0, 10, 'Observaciones:', 0, 1, 'L');
 $pdf->SetFont('Arial', '', 12);
-$pdf->MultiCell(0, 10, 'Este es un informe detallado de las camaras CCTV por planta. Los datos presentados muestran el estado de operatividad de cada camara en cada planta del cliente registrado.');
+$pdf->MultiCell(0, 10, $informe['observaciones']);
 
 // Salida del PDF
 $pdf->Output();


### PR DESCRIPTION
- Se agregan los botones para habilitar o deshabilitar un reporte solo si la cuenta tiene un perfil de admin o supervisor. 
- Se conecta el reportetest.php con la base de datos para que el pdf traiga datos reales. 
- Se soluciona un bug donde la tabla de reportes no se veía correctamente en modo oscuro.